### PR TITLE
revert logging for python 3.7 and fix broken configs

### DIFF
--- a/pax/conf/experiment/ipd/earl_nl_open.yaml
+++ b/pax/conf/experiment/ipd/earl_nl_open.yaml
@@ -13,6 +13,7 @@ payoff: [[-1, -1], [-3, 0], [0, -3], [-2, -2]]
 
 # Runner 
 evo: True 
+num_devices: 1
 
 # Training
 top_k: 5
@@ -61,6 +62,7 @@ ppo:
   learning_rate: 1
   adam_epsilon: 1e-5
   with_memory: True
+  with_cnn: False
 
 # Naive Learner parameters 
 naive:

--- a/pax/runner_evo.py
+++ b/pax/runner_evo.py
@@ -423,7 +423,7 @@ class EvoRunner:
                             rewards_1.mean()
                         ),
                     }
-                    wandb_log = wandb_log | env_stats
+                    wandb_log.update(env_stats)
                     # loop through population
                     for idx, (overall_fitness, gen_fitness) in enumerate(
                         zip(log["top_fitness"], log["top_gen_fitness"])
@@ -440,13 +440,8 @@ class EvoRunner:
                     flattened_metrics = jax.tree_util.tree_map(
                         lambda x: jnp.sum(jnp.mean(x, 1)), a2_metrics
                     )
-                    agent2._logger.metrics = (
-                        agent2._logger.metrics | flattened_metrics
-                    )
-
-                    agent1._logger.metrics = (
-                        agent1._logger.metrics | flattened_metrics
-                    )
+                    agent2._logger.metrics.update(flattened_metrics)
+                    agent1._logger.metrics.update(flattened_metrics)
                     agents.log(watchers)
                     wandb.log(wandb_log)
             self.generations += 1


### PR DESCRIPTION
revert logging for python 3.7 and fix broken configs in EARL vs. PPO in IPD 