### PR TITLE
fix saving for evolution runner

### DIFF
--- a/pax/conf/experiment/ipd/earl_v_ppo.yaml
+++ b/pax/conf/experiment/ipd/earl_v_ppo.yaml
@@ -45,7 +45,6 @@ num_seeds: 20
 run_path: ucl-dark/ipd/1ui7wfop
 model_path: exp/EARL-PPO_memory-vs-PPO/run-seed-25-OpenES-pop-size-1000-num-opps-1/2022-09-15_02.32.16.559924/generation_2900
 
-
 # PPO agent parameters
 ppo:
   num_minibatches: 4


### PR DESCRIPTION
Reverted the change made to how saving works in runner_evo. The evosax does not work as intended, so this is is the work around. 